### PR TITLE
Deathlink: fix multisends, new causes and popup

### DIFF
--- a/Emerald-Archipelago/ap/ArchipelagoClient.gd
+++ b/Emerald-Archipelago/ap/ArchipelagoClient.gd
@@ -265,7 +265,8 @@ func _on_data(packet: PackedByteArray):
 				if message["data"].has("source"):
 					first_sentence = "Received Death from %s" % message["data"]["source"]
 				if message["data"].has("cause") and message["data"]["cause"] != "":
-					second_sentence = ". Reason: %s" % message["data"]["cause"]
+					#second_sentence = ". Reason: %s" % message["data"]["cause"]
+					first_sentence = message["data"]["cause"]
 				emit_signal("logInformations", first_sentence + second_sentence)
 				# Makes the dome explode !
 				emit_signal("onDeathFound")

--- a/Emerald-Archipelago/ap/ArchipelagoClient.gd
+++ b/Emerald-Archipelago/ap/ArchipelagoClient.gd
@@ -252,14 +252,14 @@ func _on_data(packet: PackedByteArray):
 						"Sent [color=%s]%s[/color] to %s" % [item_color, item_name, player_name]
 					)
 		elif cmd == "Bounced":
-			if not _death_link:
-				return
-			if (message.has("tags") and message.has("data") and message["tags"].has("DeathLink")):
+			# Deathlink
+			if (_death_link and message.has("tags") and message.has("data") and message["tags"].has("DeathLink")):
 				if message["data"].has("source") and message["data"]["source"] == _ap_user:
 					return # Skip deaths from self
 				var tstamp: float = message["data"].get("time", 0.0)
-				if is_equal_approx(tstamp, last_sent_deathlink_time):
-					return # Skip deaths from self
+				var deathlink_lastvsnow_sec = tstamp - last_sent_deathlink_time
+				if deathlink_lastvsnow_sec < 2:
+					return # Skip deaths too close to the previous death.
 				var first_sentence = "Received Death"
 				var second_sentence = ""
 				if message["data"].has("source"):
@@ -267,7 +267,6 @@ func _on_data(packet: PackedByteArray):
 				if message["data"].has("cause") and message["data"]["cause"] != "":
 					second_sentence = ". Reason: %s" % message["data"]["cause"]
 				emit_signal("logInformations", first_sentence + second_sentence)
-
 				# Makes the dome explode !
 				emit_signal("onDeathFound")
 

--- a/Emerald-Archipelago/ap/ArchipelagoClient.gd
+++ b/Emerald-Archipelago/ap/ArchipelagoClient.gd
@@ -435,6 +435,7 @@ func connectToRoom(ap_user, ap_pass):
 func sendDeath(cause: String):
 	if not _death_link:
 		return
+	emit_signal("logInformations", "Sending Death")
 	last_sent_deathlink_time = Time.get_unix_time_from_system()
 	sendMessage(
 		[

--- a/Emerald-Archipelago/ap/ArchipelagoClient.gd
+++ b/Emerald-Archipelago/ap/ArchipelagoClient.gd
@@ -34,6 +34,7 @@ var _slot_data = {} ## Information of the slot this client is connected to. Stuf
 var _received_indexes = []
 
 var _death_link: bool ## Wether death link is enabled or not.
+var last_sent_deathlink_time: float
 
 signal could_not_connect(errorMessage)
 signal connect_status(message)
@@ -251,15 +252,14 @@ func _on_data(packet: PackedByteArray):
 						"Sent [color=%s]%s[/color] to %s" % [item_color, item_name, player_name]
 					)
 		elif cmd == "Bounced":
-			if (
-				_death_link
-				and message.has("tags")
-				and message.has("data")
-				and message["tags"].has("DeathLink")
-			):
+			if not _death_link:
+				return
+			if (message.has("tags") and message.has("data") and message["tags"].has("DeathLink")):
 				if message["data"].has("source") and message["data"]["source"] == _ap_user:
-					return
-				
+					return # Skip deaths from self
+				var tstamp: float = message["data"].get("time", 0.0)
+				if is_equal_approx(tstamp, last_sent_deathlink_time):
+					return # Skip deaths from self
 				var first_sentence = "Received Death"
 				var second_sentence = ""
 				if message["data"].has("source"):
@@ -434,20 +434,22 @@ func connectToRoom(ap_user, ap_pass):
 	)
 	
 func sendDeath(cause: String):
-	if _death_link:
-		sendMessage(
-			[
-				{
-					"cmd": "Bounce",
-					"tags": ["DeathLink"],
-					"data": {
-						"time": Time.get_unix_time_from_system(),
-						"cause": cause,
-						"source": _ap_user
-					}
+	if not _death_link:
+		return
+	last_sent_deathlink_time = Time.get_unix_time_from_system()
+	sendMessage(
+		[
+			{
+				"cmd": "Bounce",
+				"tags": ["DeathLink"],
+				"data": {
+					"time": last_sent_deathlink_time,
+					"cause": cause,
+					"source": _ap_user
 				}
-			]
-		)
+			}
+		]
+	)
 
 func colorForItemType(flags):
 	var int_flags = int(flags)

--- a/Emerald-Archipelago/mod_main.gd
+++ b/Emerald-Archipelago/mod_main.gd
@@ -538,6 +538,7 @@ func _parse_hint(hint_location:String) -> void:
 func _death_found() -> void: # If server sends death link death. Kill client if in battle scene.
 	if battleScene == null: return
 	if apClient._death_link == false: return
+	Effects.floating_text("DEATHLINKED", battleScene.player_cursor.global_position, MyColors.RED)
 	battleScene.health_bar.die()
 
 # Send Information to Server

--- a/Emerald-Archipelago/mod_main.gd
+++ b/Emerald-Archipelago/mod_main.gd
@@ -132,6 +132,7 @@ const item_descriptions: Dictionary = {
 var killed_last_boss: bool = false
 
 # Etc Variables
+var was_killed_by_deathlink: bool = false
 
 func _init() -> void:
 	ModLoaderMod.add_hook(_ap_on_boss_defeated,"res://Scripts/Battle/BattleScene.gd","_on_boss_defeated")
@@ -537,8 +538,9 @@ func _parse_hint(hint_location:String) -> void:
 
 
 func _death_found() -> void: # If server sends death link death. Kill client if in battle scene.
-	if battleScene == null: return
 	if apClient._death_link == false: return
+	if battleScene == null: return
+	was_killed_by_deathlink = true
 	Effects.floating_text("DEATHLINKED", battleScene.player_cursor.global_position, MyColors.RED)
 	battleScene.health_bar.die()
 
@@ -814,20 +816,20 @@ func _setup_battle_scene(battleScn: BattleScene) -> void: # When battle scene is
 
 func _health_zeroed_in_fight() -> void: # When you lost all health in battle scene. send death through death link if enabled.
 	if is_client_connected == false: return
+	if was_killed_by_deathlink == true:
+		was_killed_by_deathlink = false
+		return
 	if apClient._death_link == true:
 		var deathlink_message = _generate_deathlink_message()
 		apClient.sendDeath(deathlink_message)
 
 func _generate_deathlink_message() -> String:
 	var deathlink_message = ""
-	var rare_chance = [1,2,3,4].pick_random()
-	if rare_chance > 1:
-		set(deathlink_message, "%s's session was terminated." % [_ap_user])
-	else:
-		var rare_death_msgs = [
-			"%s 401'd" % [_ap_user],
-			"%s was terminated at prestige %s" % [_ap_user, State.curr_prestige],
-			"%s failed to nodebust." % [_ap_user],
-		]
-		set(deathlink_message, rare_death_msgs.pick_random())
+	var possible_death_msgs = [
+			"%s's session was terminated." % [apClient._ap_user],
+			"%s 401'd." % [apClient._ap_user],
+			"%s was terminated at prestige %s." % [apClient._ap_user, State.curr_prestige],
+			"%s failed to nodebust." % [apClient._ap_user],
+	]
+	deathlink_message = possible_death_msgs.pick_random()
 	return deathlink_message

--- a/Emerald-Archipelago/mod_main.gd
+++ b/Emerald-Archipelago/mod_main.gd
@@ -131,6 +131,7 @@ const item_descriptions: Dictionary = {
 # Battle Variables
 var killed_last_boss: bool = false
 
+# Etc Variables
 
 func _init() -> void:
 	ModLoaderMod.add_hook(_ap_on_boss_defeated,"res://Scripts/Battle/BattleScene.gd","_on_boss_defeated")
@@ -813,5 +814,20 @@ func _setup_battle_scene(battleScn: BattleScene) -> void: # When battle scene is
 
 func _health_zeroed_in_fight() -> void: # When you lost all health in battle scene. send death through death link if enabled.
 	if is_client_connected == false: return
-	if apClient._death_link == false: return
-	apClient.sendDeath("Session Terminated.")
+	if apClient._death_link == true:
+		var deathlink_message = _generate_deathlink_message()
+		apClient.sendDeath(deathlink_message)
+
+func _generate_deathlink_message() -> String:
+	var deathlink_message = ""
+	var rare_chance = [1,2,3,4].pick_random()
+	if rare_chance > 1:
+		set(deathlink_message, "%s's session was terminated." % [_ap_user])
+	else:
+		var rare_death_msgs = [
+			"%s 401'd" % [_ap_user],
+			"%s was terminated at prestige %s" % [_ap_user, State.curr_prestige],
+			"%s failed to nodebust." % [_ap_user],
+		]
+		set(deathlink_message, rare_death_msgs.pick_random())
+	return deathlink_message


### PR DESCRIPTION
- New "Level Up" style deathlink popup
- New deathlink messages to pick from
- Add buffer to prevent consecutive sends
- Add condition to prevent sends caused by deathlink
- Rework client logging
  - Log "Sending Death" on send
  - Only log deathlink cause if present