### PR TITLE
Validation: Set Upgrade Nodes to checked "continuous" max level

### DIFF
--- a/Emerald-Archipelago/mod_main.gd
+++ b/Emerald-Archipelago/mod_main.gd
@@ -361,14 +361,28 @@ func _set_upgrade_nodes_on_connection() -> void:
 # Aggregate max level of checked upgrade locations
 func _get_collected_upgrade_locations_and_levels() -> Dictionary:
 	var cached_upgrade_locs = {}
+	var location_names = []
 	if is_client_connected == false:
 		return cached_upgrade_locs
 	for loc in apClient._checked_locations:
 		var loc_name = apClient._location_id_to_name[loc]
 		var loc_and_level = loc_name.rsplit("-", false, 2)
 		if UpgradeStore.search(loc_and_level[0]) != null:
+			location_names.append(loc_name)
 			if (loc_and_level[0] not in cached_upgrade_locs) or (cached_upgrade_locs[loc_and_level[0]] < loc_and_level[1]):
 				cached_upgrade_locs[loc_and_level[0]] = loc_and_level[1]
+	# Validate we have a continuous max level, otherwise lower it to prevent softlocking out of checks
+	var continuous_max = 1
+	var continuous_failed = false
+	var supposed_max = 0
+	for upgrade in cached_upgrade_locs:
+		supposed_max = cached_upgrade_locs[upgrade]
+		while (continuous_max <= supposed_max) or continuous_failed == false:
+			continuous_failed = false
+			var continuous_location: String = str(upgrade) + "-" + str(continuous_max)
+			if continuous_location not in location_names:
+				cached_upgrade_locs[upgrade] = continuous_max
+				continuous_failed = true
 	return cached_upgrade_locs
 
 

--- a/Emerald-Archipelago/mod_main.gd
+++ b/Emerald-Archipelago/mod_main.gd
@@ -375,14 +375,17 @@ func _get_collected_upgrade_locations_and_levels() -> Dictionary:
 	var continuous_max = 1
 	var continuous_failed = false
 	var supposed_max = 0
+	var continuous_location: String = ""
 	for upgrade in cached_upgrade_locs:
 		supposed_max = cached_upgrade_locs[upgrade]
+		continuous_max = 1
+		continuous_failed = false
 		while (continuous_max <= supposed_max) or continuous_failed == false:
-			continuous_failed = false
-			var continuous_location: String = str(upgrade) + "-" + str(continuous_max)
+			continuous_location = str(upgrade) + "-" + str(continuous_max)
 			if continuous_location not in location_names:
-				cached_upgrade_locs[upgrade] = continuous_max
+				cached_upgrade_locs[upgrade] = continuous_max - 1
 				continuous_failed = true
+			continuous_max = continuous_max + 1
 	return cached_upgrade_locs
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Locations (checks) are the upgrade nodes in the upgrade tree, Milestone rewards,
 * [Nodebuster (Steam)](https://store.steampowered.com/app/3107330)
     * Windows
 * [Godot 4.x Mod Loader](https://github.com/GodotModding/godot-mod-loader/releases) v7.0.1 or later
-    * We use this version for the [patch](https://github.com/GodotModding/godot-mod-loader/pull/533) that provides compatibility to Nodebuster.
 * [Nodebuster Archipelago Mod](https://github.com/josephwhite/Emerlads-Nodebuster_AP_Mod/releases)
 
 ## Optional Software


### PR DESCRIPTION
Reduces checked max level of upgrade nodes to the highest continuous level.
To prevent potential soft locking out of upgrade locations.
Resolves #37